### PR TITLE
make management policy optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ module "es" {
 |------|-------------|:----:|:-----:|:-----:|
 | advanced\_options | Map of key-value string pairs to specify advanced configuration options. Note that the values for these configuration options must be strings (wrapped in quotes) or they may be wrong and cause a perpetual diff, causing Terraform to want to recreate your Elasticsearch domain on every apply. | map(string) | `{}` | no |
 | create\_iam\_service\_linked\_role | Whether to create IAM service linked role for AWS ElasticSearch service. Can be only one per AWS account. | bool | `"true"` | no |
+| create\_management\_access\_policy | Whether to create the AWS Elasticsearch domain policy for management access | bool | `"true"` | no |
 | dedicated\_master\_threshold | The number of instances above which dedicated master nodes will be used. Default: 10 | number | `"10"` | no |
 | dedicated\_master\_type | ES instance type to be used for dedicated masters (default same as instance_type) | string | `"false"` | no |
 | domain\_name | Domain name for Elasticsearch cluster | string | `"es-domain"` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 data "aws_iam_policy_document" "es_management_access" {
-  count = false == local.inside_vpc ? 1 : 0
+  count = false == local.inside_vpc && var.create_management_access_policy ? 1 : 0
 
   statement {
     actions = [
@@ -98,7 +98,7 @@ resource "aws_elasticsearch_domain" "es" {
 }
 
 resource "aws_elasticsearch_domain_policy" "es_management_access" {
-  count = false == local.inside_vpc ? 1 : 0
+  count = false == local.inside_vpc && var.create_management_access_policy ? 1 : 0
 
   domain_name     = local.domain_name
   access_policies = data.aws_iam_policy_document.es_management_access[0].json

--- a/main_vpc.tf
+++ b/main_vpc.tf
@@ -2,7 +2,7 @@
 does not handle properly null/empty "vpc_options" */
 
 data "aws_iam_policy_document" "es_vpc_management_access" {
-  count = local.inside_vpc ? 1 : 0
+  count = local.inside_vpc && var.create_management_access_policy ? 1 : 0
 
   statement {
     actions = [
@@ -104,7 +104,7 @@ resource "aws_elasticsearch_domain" "es_vpc" {
 }
 
 resource "aws_elasticsearch_domain_policy" "es_vpc_management_access" {
-  count = local.inside_vpc ? 1 : 0
+  count = local.inside_vpc && var.create_management_access_policy ? 1 : 0
 
   domain_name     = local.domain_name
   access_policies = data.aws_iam_policy_document.es_vpc_management_access[0].json

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,12 @@ variable "encrypt_at_rest" {
   default     = false
 }
 
+variable "create_management_access_policy" {
+  description = "Whether to create the AWS Elasticsearch domain policy for management access"
+  type        = bool
+  default     = true
+}
+
 variable "management_iam_roles" {
   description = "List of IAM role ARNs from which to permit management traffic (default ['*']).  Note that a client must match both the IP address and the IAM role patterns in order to be permitted access."
   type        = list(string)


### PR DESCRIPTION
currently the module requires that we give it a user or role that has `es:*` access to the elasticsearch domain.  we're managing access through policies attached to the individual roles instead.

if this looks ok, i'll make the same PR to the upstream module